### PR TITLE
Add database migration for turns.metadata column

### DIFF
--- a/backend/migrations/002_add_turns_metadata.py
+++ b/backend/migrations/002_add_turns_metadata.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Migration 002: Add metadata column to turns table
+
+This migration adds the metadata column to the turns table for storing
+JSON metadata about confirmations and other turn-specific data.
+
+Run with: python3 backend/migrations/002_add_turns_metadata.py
+Or with custom DB path: python3 backend/migrations/002_add_turns_metadata.py /path/to/theo.db
+"""
+
+import sqlite3
+import os
+import sys
+from datetime import datetime
+
+# Determine database path
+def get_db_path():
+    """Get database path from command line arg or default location."""
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+
+    # Default: project root /data/theo.db
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        "data",
+        "theo.db"
+    )
+
+def run_migration():
+    """Execute the migration."""
+    DB_PATH = get_db_path()
+
+    print(f"[MIGRATION 002] Starting migration...")
+    print(f"[MIGRATION 002] Database: {DB_PATH}")
+
+    if not os.path.exists(DB_PATH):
+        print(f"[MIGRATION 002] ERROR: Database not found at {DB_PATH}")
+        return False
+
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+
+    try:
+        # Check if metadata column already exists
+        cursor.execute("PRAGMA table_info(turns)")
+        columns = [row[1] for row in cursor.fetchall()]
+
+        if "metadata" in columns:
+            print("[MIGRATION 002] ✓ metadata column already exists, skipping")
+            return True
+
+        # Add metadata column to turns table
+        print("[MIGRATION 002] Adding metadata column to turns table...")
+        cursor.execute("""
+            ALTER TABLE turns
+            ADD COLUMN metadata TEXT
+        """)
+
+        conn.commit()
+        print("[MIGRATION 002] ✓ Migration completed successfully")
+        return True
+
+    except Exception as e:
+        print(f"[MIGRATION 002] ✗ Migration failed: {e}")
+        conn.rollback()
+        return False
+
+    finally:
+        conn.close()
+
+if __name__ == "__main__":
+    success = run_migration()
+    sys.exit(0 if success else 1)

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -1,0 +1,50 @@
+# Database Migrations
+
+This directory contains database migration scripts for THEO.
+
+## Running Migrations
+
+### Local Development
+
+Run migrations against the local database:
+
+```bash
+python3 backend/migrations/001_add_action_tables.py
+python3 backend/migrations/002_add_turns_metadata.py
+```
+
+### Production / AWS
+
+Run migrations against a remote database by providing the database path:
+
+```bash
+python3 backend/migrations/002_add_turns_metadata.py /path/to/production/theo.db
+```
+
+Or SSH into your AWS instance and run:
+
+```bash
+cd /path/to/theo
+python3 backend/migrations/002_add_turns_metadata.py
+```
+
+## Migration List
+
+| Migration | Description | Status |
+|-----------|-------------|--------|
+| 001_add_action_tables.py | Initial action system tables | ✓ |
+| 002_add_turns_metadata.py | Add metadata column to turns table | ✓ |
+
+## Creating New Migrations
+
+1. Create a new file: `backend/migrations/00X_description.py`
+2. Follow the pattern from existing migrations
+3. Include rollback/safety checks (e.g., checking if column exists)
+4. Test locally before deploying
+5. Update this README
+
+## Notes
+
+- Migrations are idempotent - safe to run multiple times
+- Always backup the database before running migrations in production
+- Migrations check for existing schema elements before making changes


### PR DESCRIPTION
- Create migration 002 to add metadata column to turns table
- Migration is idempotent (checks if column exists before adding)
- Supports custom database path via command line argument
- Add migrations README with instructions for local and production use

This fixes the AWS deployment error: "no such column: turns.metadata"

To apply on AWS:
python3 backend/migrations/002_add_turns_metadata.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)