### PR TITLE
fix: Support all LLM providers for email summarization

### DIFF
--- a/backend/core/actions/email_handlers.py
+++ b/backend/core/actions/email_handlers.py
@@ -775,6 +775,10 @@ Generate the email with subject and body:"""
             AI-generated summary of emails
         """
         from providers.openai import OpenAIProvider
+        from providers.anthropic import AnthropicProvider
+        from providers.gemini import GoogleProvider
+        from providers.grok import XAIProvider
+        from providers.mistral import MistralProvider
         from core.provider_registry import ProviderRegistry
 
         try:
@@ -808,8 +812,32 @@ Generate the email with subject and body:"""
                     base_url=provider_cfg.get("base_url"),
                     model=provider_cfg.get("model") or "gpt-4o-mini"
                 )
+            elif provider_type == "anthropic":
+                provider = AnthropicProvider(
+                    api_key=provider_cfg["api_key"],
+                    base_url=provider_cfg.get("base_url"),
+                    model=provider_cfg.get("model")
+                )
+            elif provider_type == "google":
+                provider = GoogleProvider(
+                    api_key=provider_cfg["api_key"],
+                    base_url=provider_cfg.get("base_url"),
+                    model=provider_cfg.get("model")
+                )
+            elif provider_type == "xai":
+                provider = XAIProvider(
+                    api_key=provider_cfg["api_key"],
+                    base_url=provider_cfg.get("base_url"),
+                    model=provider_cfg.get("model")
+                )
+            elif provider_type == "mistral":
+                provider = MistralProvider(
+                    api_key=provider_cfg["api_key"],
+                    base_url=provider_cfg.get("base_url"),
+                    model=provider_cfg.get("model")
+                )
             else:
-                # For now, only OpenAI is supported for lightweight tasks
+                # Unknown provider type
                 logging.warning(f"[EMAIL_HANDLERS] Provider type {provider_type} not supported for lightweight tasks, using basic email list")
                 return self._format_email_list(emails, unread_only)
 


### PR DESCRIPTION
Previously, email inbox summaries only worked with OpenAI providers, falling back to basic bullet lists when using other providers like Gemini, Anthropic, etc.

Now supports all provider types:
- OpenAI
- Anthropic (Claude)
- Google (Gemini)
- XAI (Grok)
- Mistral

This allows the "system" routing preference to work correctly with any configured LLM provider for email summarization.

Fixes action router email handler to properly use configured system provider instead of falling back to basic list formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)