### PR TITLE
fix: Correct ProviderRegistry method name in email handlers

### DIFF
--- a/backend/core/actions/email_handlers.py
+++ b/backend/core/actions/email_handlers.py
@@ -498,7 +498,7 @@ class EmailHandlers(BaseActionHandler):
 
             if system_provider_id:
                 # Use configured system provider
-                provider_cfg = registry.get_by_id(system_provider_id)
+                provider_cfg = registry.get(system_provider_id)
                 logging.info(f"[EMAIL_HANDLERS] Using configured system provider: {system_provider_id}")
 
             if not provider_cfg or not provider_cfg.get("api_key"):
@@ -653,7 +653,7 @@ Generate a reply email body:"""
 
             if system_provider_id:
                 # Use configured system provider
-                provider_cfg = registry.get_by_id(system_provider_id)
+                provider_cfg = registry.get(system_provider_id)
                 logging.info(f"[EMAIL_HANDLERS] Using configured system provider: {system_provider_id}")
 
             if not provider_cfg or not provider_cfg.get("api_key"):
@@ -791,7 +791,7 @@ Generate the email with subject and body:"""
 
             if system_provider_id:
                 # Use configured system provider
-                provider_cfg = registry.get_by_id(system_provider_id)
+                provider_cfg = registry.get(system_provider_id)
                 logging.info(f"[EMAIL_HANDLERS] Using configured system provider: {system_provider_id}")
 
             if not provider_cfg or not provider_cfg.get("api_key"):


### PR DESCRIPTION
Changed `registry.get_by_id()` to `registry.get()` to match the actual ProviderRegistry API. This was causing email summarization to fail with AttributeError.

Error was: 'ProviderRegistry' object has no attribute 'get_by_id'

Now email summarization will properly use the configured system provider (e.g., Gemini Flash) for generating conversational summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)