### PR TITLE
Fix migration 012: resolve global declaration error

### DIFF
--- a/backend/migrations/012_add_feature_provider_usage_logs.py
+++ b/backend/migrations/012_add_feature_provider_usage_logs.py
@@ -81,9 +81,60 @@ def run_migration():
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:
-        # Override get_db_path when called from migration runner
-        global get_db_path
-        db_arg = sys.argv[1]
-        get_db_path = lambda: db_arg
+        # Override get_db_path by directly using the argument
+        db_path = sys.argv[1]
 
-    run_migration()
+        # Create a wrapper function that uses the passed path
+        def run_with_custom_path():
+            conn = sqlite3.connect(db_path)
+            cursor = conn.cursor()
+
+            print("[MIGRATION 012] Starting migration...")
+            print(f"[MIGRATION 012] Database: {db_path}")
+
+            # Check if table already exists
+            cursor.execute("""
+                SELECT name FROM sqlite_master
+                WHERE type='table' AND name='feature_provider_usage_logs'
+            """)
+
+            if cursor.fetchone():
+                print("[MIGRATION 012] ✓ feature_provider_usage_logs table already exists, skipping")
+                conn.close()
+                return True
+
+            # Create feature_provider_usage_logs table
+            print("[MIGRATION 012] Creating feature_provider_usage_logs table...")
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS feature_provider_usage_logs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id TEXT NOT NULL,
+                    provider_type VARCHAR(50) NOT NULL,
+                    success BOOLEAN DEFAULT 1,
+                    latency_ms INTEGER,
+                    error_message TEXT,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
+            # Create index for faster queries
+            print("[MIGRATION 012] Creating indexes...")
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_feature_provider_usage_user_provider
+                ON feature_provider_usage_logs(user_id, provider_type)
+            """)
+
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_feature_provider_usage_created_at
+                ON feature_provider_usage_logs(created_at)
+            """)
+
+            conn.commit()
+            conn.close()
+
+            print("[MIGRATION 012] ✓ Migration completed successfully")
+            return True
+
+        run_with_custom_path()
+    else:
+        run_migration()


### PR DESCRIPTION
The issue was trying to use 'global get_db_path' after assigning to it, which is a SyntaxError in Python. Instead, when called with a custom database path (from migration runner), we now create a dedicated wrapper function that directly uses the passed db_path argument.

This avoids the global declaration issue while still supporting both:
- Direct execution (uses get_db_path() function)
- Migration runner execution (uses sys.argv[1] directly)