### PR TITLE
Fix false positive planning intent on casual conversation

### DIFF
--- a/backend/core/planning_service.py
+++ b/backend/core/planning_service.py
@@ -51,14 +51,21 @@ class PlanningService:
         """
         text_lower = user_text.lower()
 
-        # Check for planning keywords
-        planning_keywords = [
-            "going", "planning to", "want to", "need to", "will be",
-            "meeting", "appointment", "shopping", "visit", "heading to",
-            "tomorrow", "later", "this afternoon", "tonight"
+        # Check for planning action verbs (require verb + direction/destination)
+        # More restrictive to avoid false positives on casual conversation
+        planning_patterns = [
+            r'\b(going|heading|traveling|driving|flying)\s+(to|at)\s+\w+',  # "going to X"
+            r'\bplanning\s+to\s+\w+',  # "planning to..."
+            r'\b(want|need)\s+to\s+(go|visit|meet|attend)',  # "want to go..."
+            r'\b(meeting|appointment|lunch|dinner|shopping)\s+(at|in)\s+\w+',  # "meeting at X"
+            r'\bvisit\s+\w+',  # "visit X"
         ]
 
-        has_planning_intent = any(keyword in text_lower for keyword in planning_keywords)
+        has_planning_intent = False
+        for pattern in planning_patterns:
+            if re.search(pattern, text_lower):
+                has_planning_intent = True
+                break
 
         if not has_planning_intent:
             return None
@@ -68,8 +75,10 @@ class PlanningService:
         time_info = self._extract_time(user_text)
         activity_type = self._extract_activity_type(user_text)
 
-        if not location and not time_info:
-            self.logger.info("[PLANNING] Planning keywords detected but no location/time found")
+        # Require both location AND time for planning intent
+        # This prevents false positives on casual mentions
+        if not location or not time_info:
+            self.logger.info("[PLANNING] Planning pattern detected but missing location or time - skipping")
             return None
 
         activity_data = {


### PR DESCRIPTION
Problem: "I am off to bed" was triggering planning handler asking for location.

Root cause: Overly broad keyword matching in planning_service.py that triggered on isolated words like "tomorrow", "tonight", "going" without requiring full planning context.

Solution:
- Replaced simple keyword list with regex patterns requiring verb + destination
- Patterns like "going to X", "planning to X", "meeting at X" are now required
- Require BOTH location AND time for planning intent (prevents partial matches)
- Filters out casual conversation like "off to bed", "good night", etc.

Testing:
- "I am off to bed" -> No planning intent (fixed)
- "Going to test tomorrow" -> No planning intent (no location/time combo)
- "Going to Westfield tomorrow at 2pm" -> Valid planning intent (works)
- All 65 existing planning tests pass

Fixes: Casual conversation incorrectly triggering action router