### PR TITLE
Fix Debug Console to use relative URLs on AWS

### DIFF
--- a/frontend/src/components/settings/DebugConsole.svelte
+++ b/frontend/src/components/settings/DebugConsole.svelte
@@ -38,8 +38,8 @@
 
   async function checkDebugStatus() {
     try {
-      // Use full API URL to handle different environments
-      const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:1066';
+      // Use relative URL like rest of the app
+      const API_BASE = "";
       const response = await fetch(`${API_BASE}/api/debug/status`);
       const data = await response.json();
       debugEnabled = data.enabled;


### PR DESCRIPTION
ISSUE: Debug Console trying to connect to localhost:1066 on AWS
- Browser console showed: ERR_CONNECTION_REFUSED on localhost:1066
- Frontend hardcoded API_BASE with localhost fallback

FIX: Use empty string for relative URLs (matches rest of app)
- Changed API_BASE from 'http://localhost:1066' fallback to ""
- Consistent with lib/api.js which uses relative URLs
- Works in all environments (local dev, AWS, Docker)

FILE CHANGED:
- frontend/src/components/settings/DebugConsole.svelte:42

This allows Debug Console to work on AWS deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)