### PR TITLE
Add pre-migration cleanup for duplicate preferences (Migration 018)

### DIFF
--- a/backend/db_backup.py
+++ b/backend/db_backup.py
@@ -140,6 +140,7 @@ def run_migrations(db_path: str):
         "015_add_proactive_tracking_tables.py",
         "016_add_routine_tracking.py",
         "017_add_user_routines.py",
+        "018_1_cleanup_duplicate_preferences.py",  # Pre-migration cleanup
         "018_standardize_user_id_to_integer.py",
         "019_create_debug_logs.py"
     ]

--- a/backend/migrations/018_1_cleanup_duplicate_preferences.py
+++ b/backend/migrations/018_1_cleanup_duplicate_preferences.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Pre-migration cleanup for Migration 018: Remove duplicate 'local' user_id preferences
+
+This script removes preferences entries with user_id='local' that would conflict
+with existing user_id=1 entries when migration 018 converts 'local' to 1.
+
+Run with: python3 backend/migrations/018_1_cleanup_duplicate_preferences.py
+Or with custom DB path: python3 backend/migrations/018_1_cleanup_duplicate_preferences.py /path/to/theo.db
+"""
+
+import sqlite3
+import os
+import sys
+
+def get_db_path():
+    """Get database path from command line arg or default location."""
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+
+    # Default: project root /data/theo.db
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        "data",
+        "theo.db"
+    )
+
+def run_cleanup():
+    """Execute the cleanup."""
+    DB_PATH = get_db_path()
+
+    print(f"[CLEANUP 018] Starting duplicate preferences cleanup...")
+    print(f"[CLEANUP 018] Database: {DB_PATH}")
+
+    if not os.path.exists(DB_PATH):
+        print(f"[CLEANUP 018] ERROR: Database not found at {DB_PATH}")
+        return False
+
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+
+    try:
+        # Check if preferences table exists
+        cursor.execute("""
+            SELECT name FROM sqlite_master
+            WHERE type='table' AND name='preferences'
+        """)
+
+        if not cursor.fetchone():
+            print("[CLEANUP 018] ✓ preferences table doesn't exist yet, skipping")
+            return True
+
+        # Get all preferences with user_id='local'
+        cursor.execute("""
+            SELECT user_id, key, value FROM preferences
+            WHERE user_id = 'local'
+        """)
+        local_prefs = cursor.fetchall()
+
+        if not local_prefs:
+            print("[CLEANUP 018] ✓ No 'local' user_id preferences found, skipping")
+            return True
+
+        print(f"[CLEANUP 018] Found {len(local_prefs)} 'local' user_id preferences")
+
+        # For each 'local' preference, check if user_id=1 has the same key
+        duplicates_to_delete = []
+        for user_id, key, value in local_prefs:
+            cursor.execute("""
+                SELECT 1 FROM preferences
+                WHERE user_id = 1 AND key = ?
+            """, (key,))
+
+            if cursor.fetchone():
+                # Duplicate exists - delete the 'local' version
+                duplicates_to_delete.append(key)
+                print(f"[CLEANUP 018]   Duplicate found: {key} (will delete 'local' version)")
+            else:
+                # No duplicate - migration 018 will safely convert this to user_id=1
+                print(f"[CLEANUP 018]   No conflict: {key} (will be migrated)")
+
+        if duplicates_to_delete:
+            # Delete duplicate 'local' preferences
+            placeholders = ','.join('?' * len(duplicates_to_delete))
+            cursor.execute(f"""
+                DELETE FROM preferences
+                WHERE user_id = 'local' AND key IN ({placeholders})
+            """, duplicates_to_delete)
+
+            conn.commit()
+            print(f"[CLEANUP 018] ✓ Deleted {len(duplicates_to_delete)} duplicate 'local' preferences")
+        else:
+            print("[CLEANUP 018] ✓ No duplicates to delete")
+
+        print("[CLEANUP 018] ✓ Cleanup completed successfully")
+        return True
+
+    except Exception as e:
+        print(f"[CLEANUP 018] ✗ Cleanup failed: {e}")
+        conn.rollback()
+        return False
+
+    finally:
+        conn.close()
+
+if __name__ == "__main__":
+    success = run_cleanup()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
ISSUE: Migration 018 failing with UNIQUE constraint violation
- Preferences table had both user_id='local' and user_id=1 entries
- Both had 'last_routing_decision' key
- Migration 018 tried to convert 'local' → 1, creating duplicate

SOLUTION: Pre-migration cleanup script
- Created 018_1_cleanup_duplicate_preferences.py
- Runs before migration 018
- Deletes 'local' preferences that would conflict with user_id=1
- Keeps 'local' preferences that don't conflict (will be migrated)

TESTING:
- Tested on theo_prod_copy.db
- Successfully removed 1 duplicate (last_routing_decision)
- Kept 1 non-conflicting entry (session_timeout)
- Migration 018 should now succeed

FILES CHANGED:
- backend/migrations/018_1_cleanup_duplicate_preferences.py (new)
- backend/db_backup.py: Added cleanup to migration list

This allows migration 018 to complete successfully on AWS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)