### PR TITLE
Fix Debug Console infinite recursion crash

### DIFF
--- a/backend/core/logging_handler.py
+++ b/backend/core/logging_handler.py
@@ -80,10 +80,19 @@ class DatabaseLogHandler(logging.Handler):
                 return enabled
             except Exception as e:
                 # On error, assume disabled and cache for shorter time
+                # NOTE: Can't use logging.error here - would cause recursion!
                 self._debug_enabled_cache = False
                 self._cache_timestamp = now - self._cache_ttl + 5  # Retry in 5 seconds
-                logging.error(f"[DEBUG-HANDLER] Error checking debug_enabled: {e}")
                 return False
+
+    def invalidate_cache(self):
+        """
+        Force cache invalidation to immediately pick up debug_enabled changes.
+        Should be called when the debug_enabled preference is toggled.
+        """
+        with self._cache_lock:
+            self._cache_timestamp = 0
+            self._debug_enabled_cache = None
 
     def _extract_component(self, message: str) -> Optional[str]:
         """
@@ -107,6 +116,10 @@ class DatabaseLogHandler(logging.Handler):
         Args:
             record: LogRecord instance to be logged
         """
+        # CRITICAL: Prevent infinite recursion - don't log our own messages
+        if record.name == 'core.logging_handler' or '[DEBUG-HANDLER]' in record.getMessage():
+            return
+
         # Skip if debug mode is not enabled
         if not self._is_debug_enabled():
             return
@@ -141,6 +154,7 @@ class DatabaseLogHandler(logging.Handler):
 
         except Exception as e:
             # Don't let logging errors crash the application
+            # NOTE: Don't use logging.error here - would cause recursion!
             self.handleError(record)
 
     def _flush_worker(self):

--- a/backend/routes/debug_routes.py
+++ b/backend/routes/debug_routes.py
@@ -465,7 +465,7 @@ def toggle_debug():
 
     Requires: Admin authentication
     """
-    from app import memory
+    from app import memory, db_handler
     from core.user_utils import DEFAULT_USER_ID
 
     # Check admin status
@@ -482,5 +482,8 @@ def toggle_debug():
         key="debug_enabled",
         value=str(enabled).lower()
     )
+
+    # Invalidate cache so handler picks up change immediately
+    db_handler.invalidate_cache()
 
     return jsonify({"status": "ok", "enabled": enabled})


### PR DESCRIPTION
Issue: Enabling debug mode caused backend container to crash due to infinite recursion in DatabaseLogHandler.

Root Cause:
- DatabaseLogHandler was added to root logger
- Handler's own error logging triggered itself recursively
- Memory exhaustion → container health check failure → crash

Fixes:
1. Added recursion prevention in emit() method
   - Skip logs from core.logging_handler module
   - Skip logs with [DEBUG-HANDLER] tag
2. Removed logging.error() call in _is_debug_enabled()
   - Would cause recursion when cache refresh failed
3. Added invalidate_cache() method for immediate toggle response
4. Updated toggle endpoint to invalidate cache after preference change

Testing:
- All 11 logging handler tests pass
- Prevents infinite recursion on enable/disable
- Immediate cache refresh when toggled

🤖 Generated with [Claude Code](https://claude.com/claude-code)