### PR TITLE
Fix critical bug: /api/chat endpoint not passing text to router

### DIFF
--- a/backend/routes/message_routes.py
+++ b/backend/routes/message_routes.py
@@ -23,7 +23,7 @@ def chat():
     Request body: { "session_id": "...", "text": "..." }
     Returns: { "text": "...", "provider": "...", "model": "...", ... }
     """
-    from app import context_manager, provider_registry
+    from app import context_manager, provider_registry, memory
     from core.router import route_request
 
     payload = request.json
@@ -39,6 +39,10 @@ def chat():
     user_id = request.current_user.get("id") if hasattr(request, 'current_user') else None
 
     context = context_manager.build_context(session_id, text, user_id=user_id)
+    # FIX: route_request() needs text, session_id, and memory in the context
+    context["text"] = text
+    context["session_id"] = session_id
+    context["memory"] = memory
     result = route_request(context)
 
     # Pass the full result object so metadata can be extracted


### PR DESCRIPTION
The chat endpoint was calling context_manager.build_context() and then route_request(), but route_request() expects 'text', 'session_id', and 'memory' in the context dict. This caused all AI provider calls to fail with 'messages: at least one message is required' because the router couldn't access the user's message.

Now properly adds text, session_id, and memory to context before routing.